### PR TITLE
[kubeadm] Fix Etcd Rollback

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/staticpods.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods.go
@@ -133,8 +133,24 @@ func upgradeComponent(component string, waiter apiclient.Waiter, pathMgr StaticP
 	// Special treatment is required for etcd case, when rollbackOldManifests should roll back etcd
 	// manifests only for the case when component is Etcd
 	recoverEtcd := false
+	waitForComponentRestart := true
 	if component == constants.Etcd {
 		recoverEtcd = true
+	}
+	if isTLSUpgrade {
+		// We currently depend on getting the Etcd mirror Pod hash from the KubeAPIServer;
+		// Upgrading the Etcd protocol takes down the apiserver, so we can't verify component restarts if we restart Etcd independently.
+		// Skip waiting for Etcd to restart and immediately move on to updating the apiserver.
+		if component == constants.Etcd {
+			waitForComponentRestart = false
+		}
+		// Normally, if an Etcd upgrade is successful, but the apiserver upgrade fails, Etcd is not rolled back.
+		// In the case of a TLS upgrade, the old KubeAPIServer config is incompatible with the new Etcd confg, so we rollback Etcd
+		// if the APIServer upgrade fails.
+		if component == constants.KubeAPIServer {
+			recoverEtcd = true
+			fmt.Printf("[upgrade/staticpods] The %s manifest will be restored if component %q fails to upgrade\n", constants.Etcd, component)
+		}
 	}
 
 	// ensure etcd certs are generated for etcd and kube-apiserver
@@ -182,23 +198,6 @@ func upgradeComponent(component string, waiter apiclient.Waiter, pathMgr StaticP
 	}
 
 	fmt.Printf("[upgrade/staticpods] Moved new manifest to %q and backed up old manifest to %q\n", currentManifestPath, backupManifestPath)
-
-	waitForComponentRestart := true
-	if isTLSUpgrade {
-		// We currently depend on getting the Etcd mirror Pod hash from the KubeAPIServer;
-		// Upgrading the Etcd protocol takes down the apiserver, so we can't verify component restarts if we restart Etcd independently.
-		// Skip waiting for Etcd to restart and immediately move on to updating the apiserver.
-		if component == constants.Etcd {
-			waitForComponentRestart = false
-		}
-		// Normally, if an Etcd upgrade is successful, but the apiserver upgrade fails, Etcd is not rolled back.
-		// In the case of a TLS upgrade, the old KubeAPIServer config is incompatible with the new Etcd confg, so we rollback Etcd
-		// if the APIServer upgrade fails.
-		if component == constants.KubeAPIServer {
-			recoverEtcd = true
-			fmt.Printf("[upgrade/staticpods] The %s manifest will be restored if component %q fails to upgrade\n", constants.Etcd, component)
-		}
-	}
 
 	if waitForComponentRestart {
 		fmt.Println("[upgrade/staticpods] Waiting for the kubelet to restart the component")
@@ -274,34 +273,55 @@ func performEtcdStaticPodUpgrade(waiter apiclient.Waiter, pathMgr StaticPodPathM
 		return true, fmt.Errorf("error creating local etcd static pod manifest file: %v", err)
 	}
 
+	// Waiter configuration for checking etcd status
+	delay := 0 * time.Second
+	if isTLSUpgrade {
+		// If we are upgrading TLS we need to wait for old static pod to be removed.
+		// This is needed because we are not able to currently verify that the static pod
+		// has been updated through the apiserver across an etcd TLS upgrade.
+		// This value is arbitrary but seems to be long enough in manual testing.
+		delay = 30 * time.Second
+	}
+	retries := 10
+	retryInterval := 15 * time.Second
+
 	// Perform etcd upgrade using common to all control plane components function
 	if err := upgradeComponent(constants.Etcd, waiter, pathMgr, cfg, beforeEtcdPodHash, recoverManifests, isTLSUpgrade); err != nil {
+		fmt.Printf("[upgrade/etcd] Failed to upgrade etcd: %v\n", err)
 		// Since etcd upgrade component failed, the old manifest has been restored
 		// now we need to check the health of etcd cluster if it came back up with old manifest
-		if _, err := oldEtcdClient.GetStatus(); err != nil {
+		fmt.Println("[upgrade/etcd] Waiting for previous etcd to become available")
+		if _, err := oldEtcdClient.WaitForStatus(delay, retries, retryInterval); err != nil {
+			fmt.Printf("[upgrade/etcd] Failed to healthcheck previous etcd: %v\n", err)
+
 			// At this point we know that etcd cluster is dead and it is safe to copy backup datastore and to rollback old etcd manifest
-			if err := rollbackEtcdData(cfg, fmt.Errorf("etcd cluster is not healthy after upgrade: %v rolling back", err), pathMgr); err != nil {
+			fmt.Println("[upgrade/etcd] Rolling back etcd data")
+			if err := rollbackEtcdData(cfg, pathMgr); err != nil {
 				// Even copying back datastore failed, no options for recovery left, bailing out
 				return true, fmt.Errorf("fatal error upgrading local etcd cluster: %v, the backup of etcd database is stored here:(%s)", err, backupEtcdDir)
 			}
+			fmt.Println("[upgrade/etcd] Etcd data rollback successful")
+
 			// Old datastore has been copied, rolling back old manifests
-			if err := rollbackOldManifests(recoverManifests, err, pathMgr, true); err != nil {
-				// Rolling back to old manifests failed, no options for recovery left, bailing out
-				return true, fmt.Errorf("fatal error upgrading local etcd cluster: %v, the backup of etcd database is stored here:(%s)", err, backupEtcdDir)
-			}
-			// Since rollback of the old etcd manifest was successful, checking again the status of etcd cluster
-			if _, err := oldEtcdClient.GetStatus(); err != nil {
+			fmt.Println("[upgrade/etcd] Rolling back etcd manifest")
+			rollbackOldManifests(recoverManifests, err, pathMgr, true)
+			// rollbackOldManifests() always returns an error -- ignore it and continue
+
+			// Assuming rollback of the old etcd manifest was successful, check the status of etcd cluster again
+			fmt.Println("[upgrade/etcd] Waiting for previous etcd to become available")
+			if _, err := oldEtcdClient.WaitForStatus(delay, retries, retryInterval); err != nil {
+				fmt.Printf("[upgrade/etcd] Failed to healthcheck previous etcd: %v\n", err)
 				// Nothing else left to try to recover etcd cluster
-				return true, fmt.Errorf("fatal error upgrading local etcd cluster: %v, the backup of etcd database is stored here:(%s)", err, backupEtcdDir)
+				return true, fmt.Errorf("fatal error rolling back local etcd cluster manifest: %v, the backup of etcd database is stored here:(%s)", err, backupEtcdDir)
 			}
 
-			return true, fmt.Errorf("fatal error upgrading local etcd cluster: %v, rolled the state back to pre-upgrade state", err)
+			// We've recovered to the previous etcd from this case
 		}
+		fmt.Println("[upgrade/etcd] Etcd was rolled back and is now available")
+
 		// Since etcd cluster came back up with the old manifest
 		return true, fmt.Errorf("fatal error when trying to upgrade the etcd cluster: %v, rolled the state back to pre-upgrade state", err)
 	}
-
-	fmt.Println("[upgrade/etcd] waiting for etcd to become available")
 
 	// Initialize the new etcd client if it wasn't pre-initialized
 	if newEtcdClient == nil {
@@ -317,34 +337,31 @@ func performEtcdStaticPodUpgrade(waiter apiclient.Waiter, pathMgr StaticPodPathM
 	}
 
 	// Checking health state of etcd after the upgrade
-	delay := 0 * time.Second
-	if isTLSUpgrade {
-		// If we are upgrading TLS we need to wait for old static pod to be removed.
-		// This is needed because we are not able to currently verify that the static pod
-		// has been updated through the apiserver across an etcd TLS upgrade.
-		delay = 30 * time.Second
-	}
-	// The intial delay is required to ensure that the old static etcd pod
-	// has stopped prior to polling for status.
-	retries := 10
-	retryInterval := 15 * time.Second
+	fmt.Println("[upgrade/etcd] Waiting for etcd to become available")
 	if _, err = newEtcdClient.WaitForStatus(delay, retries, retryInterval); err != nil {
-		// Despite the fact that upgradeComponent was successful, there is something wrong with etcd cluster
+		fmt.Printf("[upgrade/etcd] Failed to healthcheck etcd: %v\n", err)
+		// Despite the fact that upgradeComponent was successful, there is something wrong with the etcd cluster
 		// First step is to restore back up of datastore
-		if err := rollbackEtcdData(cfg, fmt.Errorf("etcd cluster is not healthy after upgrade: %v rolling back", err), pathMgr); err != nil {
+		fmt.Println("[upgrade/etcd] Rolling back etcd data")
+		if err := rollbackEtcdData(cfg, pathMgr); err != nil {
 			// Even copying back datastore failed, no options for recovery left, bailing out
-			return true, fmt.Errorf("fatal error upgrading local etcd cluster: %v, the backup of etcd database is stored here:(%s)", err, backupEtcdDir)
+			return true, fmt.Errorf("fatal error rolling back local etcd cluster datadir: %v, the backup of etcd database is stored here:(%s)", err, backupEtcdDir)
 		}
+		fmt.Println("[upgrade/etcd] Etcd data rollback successful")
+
 		// Old datastore has been copied, rolling back old manifests
-		if err := rollbackOldManifests(recoverManifests, err, pathMgr, true); err != nil {
-			// Rolling back to old manifests failed, no options for recovery left, bailing out
-			return true, fmt.Errorf("fatal error upgrading local etcd cluster: %v, the backup of etcd database is stored here:(%s)", err, backupEtcdDir)
-		}
-		// Since rollback of the old etcd manifest was successful, checking again the status of etcd cluster
-		if _, err := oldEtcdClient.GetStatus(); err != nil {
+		fmt.Println("[upgrade/etcd] Rolling back etcd manifest")
+		rollbackOldManifests(recoverManifests, err, pathMgr, true)
+		// rollbackOldManifests() always returns an error -- ignore it and continue
+
+		// Assuming rollback of the old etcd manifest was successful, check the status of etcd cluster again
+		fmt.Println("[upgrade/etcd] Waiting for previous etcd to become available")
+		if _, err := oldEtcdClient.WaitForStatus(delay, retries, retryInterval); err != nil {
+			fmt.Printf("[upgrade/etcd] Failed to healthcheck previous etcd: %v\n", err)
 			// Nothing else left to try to recover etcd cluster
-			return true, fmt.Errorf("fatal error upgrading local etcd cluster: %v, the backup of etcd database is stored here:(%s)", err, backupEtcdDir)
+			return true, fmt.Errorf("fatal error rolling back local etcd cluster manifest: %v, the backup of etcd database is stored here:(%s)", err, backupEtcdDir)
 		}
+		fmt.Println("[upgrade/etcd] Etcd was rolled back and is now available")
 
 		return true, fmt.Errorf("fatal error upgrading local etcd cluster: %v, rolled the state back to pre-upgrade state", err)
 	}
@@ -438,7 +455,8 @@ func StaticPodControlPlane(waiter apiclient.Waiter, pathMgr StaticPodPathManager
 	return nil
 }
 
-// rollbackOldManifests rolls back the backuped manifests if something went wrong
+// rollbackOldManifests rolls back the backed-up manifests if something went wrong.
+// It always returns an error to the caller.
 func rollbackOldManifests(oldManifests map[string]string, origErr error, pathMgr StaticPodPathManager, restoreEtcd bool) error {
 	errs := []error{origErr}
 	for component, backupPath := range oldManifests {
@@ -459,17 +477,16 @@ func rollbackOldManifests(oldManifests map[string]string, origErr error, pathMgr
 	return fmt.Errorf("couldn't upgrade control plane. kubeadm has tried to recover everything into the earlier state. Errors faced: %v", errs)
 }
 
-// rollbackEtcdData rolls back the the content of etcd folder if something went wrong
-func rollbackEtcdData(cfg *kubeadmapi.MasterConfiguration, origErr error, pathMgr StaticPodPathManager) error {
-	errs := []error{origErr}
+// rollbackEtcdData rolls back the the content of etcd folder if something went wrong.
+// When the folder contents are successfully rolled back, nil is returned, otherwise an error is returned.
+func rollbackEtcdData(cfg *kubeadmapi.MasterConfiguration, pathMgr StaticPodPathManager) error {
 	backupEtcdDir := pathMgr.BackupEtcdDir()
 	runningEtcdDir := cfg.Etcd.DataDir
-	err := util.CopyDir(backupEtcdDir, runningEtcdDir)
 
-	if err != nil {
-		errs = append(errs, err)
+	if err := util.CopyDir(backupEtcdDir, runningEtcdDir); err != nil {
+		// Let the user know there we're problems, but we tried to reçover
+		return fmt.Errorf("couldn't recover etcd database with error: %v, the location of etcd backup: %s ", err, backupEtcdDir)
 	}
 
-	// Let the user know there we're problems, but we tried to reçover
-	return fmt.Errorf("couldn't recover etcd database with error: %v, the location of etcd backup: %s ", errs, backupEtcdDir)
+	return nil
 }


### PR DESCRIPTION
This change addresses a bug with the rollback cases where, upon a failed etcd upgrade, the data folder would be rolled back, but the etcd static pod manifest would not be leaving the cluster in an unusable state.
__________________________________________
Fix `rollbackEtcdData()` to return error=nil on success
`rollbackEtcdData()` used to always return an error making the rest of the
upgrade code completely unreachable.

Ignore errors from `rollbackOldManifests()` during the rollback since it
always returns an error.
Success of the rollback is gated with etcd L7 healthchecks.

__________________________________________
Tested wtith and without this patch (removing the CA flag from the pod to cause TLS to break):
```diff
diff --git a/cmd/kubeadm/app/phases/etcd/local.go b/cmd/kubeadm/app/phases/etcd/local.go
index d12682cd72..46b8dfdd4c 100644
--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -80,7 +80,7 @@ func getEtcdCommand(cfg *kubeadmapi.MasterConfiguration) []string {
 		"data-dir":              cfg.Etcd.DataDir,
 		"cert-file":             filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdServerCertName),
 		"key-file":              filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdServerKeyName),
-		"trusted-ca-file":       filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdCACertName),
+		// "trusted-ca-file":       filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdCACertName),
 		"client-cert-auth":      "true",
 		"peer-cert-file":        filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdPeerCertName),
 		"peer-key-file":         filepath.Join(cfg.CertificatesDir, kubeadmconstants.EtcdPeerKeyName),
```

Rollback log:
```
root@vagrant:~# /vagrant/bin/rollbackEtcd_kubeadm upgrade apply 1.10.1
[preflight] Running pre-flight checks.
[upgrade] Making sure the cluster is healthy:
[upgrade/config] Making sure the configuration is correct:
[upgrade/config] Reading configuration from the cluster...
[upgrade/config] FYI: You can look at this config file with 'kubectl -n kube-system get cm kubeadm-config -oyaml'
[upgrade/version] You have chosen to change the cluster version to "v1.10.1"
[upgrade/versions] Cluster version: v1.9.1
[upgrade/versions] kubeadm version: v1.11.0-alpha.0.2291+6d396e4c44914a-dirty
[upgrade/confirm] Are you sure you want to proceed with the upgrade? [y/N]: y
[upgrade/prepull] Will prepull images for components [kube-apiserver kube-controller-manager kube-scheduler]
[upgrade/apply] Upgrading your Static Pod-hosted control plane to version "v1.10.1"...
Static pod: kube-apiserver-vagrant hash: c6b2869a0c846c2a579220227d2d8c7e
Static pod: kube-controller-manager-vagrant hash: 2e820941c5fd15ce36157f2e06efa392
Static pod: kube-scheduler-vagrant hash: 149413a6901331c7f8577d115ee2cb68
[upgrade/etcd] Upgrading to TLS for etcd
Static pod: etcd-vagrant hash: 7278f85057e8bf5cb81c9f96d3b25320
[etcd] Wrote Static Pod manifest for a local etcd instance to "/etc/kubernetes/tmp/kubeadm-upgraded-manifests107670977/etcd.yaml"
[certificates] Generated etcd/ca certificate and key.
[certificates] Generated etcd/server certificate and key.
[certificates] etcd/server serving cert is signed for DNS names [localhost] and IPs [127.0.0.1]
[certificates] Generated etcd/peer certificate and key.
[certificates] etcd/peer serving cert is signed for DNS names [vagrant] and IPs [10.0.2.15]
[certificates] Generated etcd/healthcheck-client certificate and key.
[upgrade/staticpods] Moved new manifest to "/etc/kubernetes/manifests/etcd.yaml" and backed up old manifest to "/etc/kubernetes/tmp/kubeadm-backup-manifests399635500/etcd.yaml"
[upgrade/staticpods] Not waiting for pod-hash change for component "etcd"
[upgrade/etcd] waiting for etcd to become available
[util/etcd] Waiting 30s for initial delay
[util/etcd] Attempting to get etcd status 1/10
[util/etcd] Attempt failed with error: dial tcp [::1]:2379: connect: connection refused
[util/etcd] Waiting 15s until next retry
[util/etcd] Attempting to get etcd status 2/10
[util/etcd] Attempt failed with error: dial tcp [::1]:2379: connect: connection refused
[util/etcd] Waiting 15s until next retry
[util/etcd] Attempting to get etcd status 3/10
[util/etcd] Attempt failed with error: dial tcp [::1]:2379: connect: connection refused
[util/etcd] Waiting 15s until next retry
[util/etcd] Attempting to get etcd status 4/10
[util/etcd] Attempt timed out
[util/etcd] Waiting 15s until next retry
[util/etcd] Attempting to get etcd status 5/10
[util/etcd] Attempt timed out
[util/etcd] Waiting 15s until next retry
[util/etcd] Attempting to get etcd status 6/10
[util/etcd] Attempt timed out
[util/etcd] Waiting 15s until next retry
[util/etcd] Attempting to get etcd status 7/10
[util/etcd] Attempt timed out
[util/etcd] Waiting 15s until next retry
[util/etcd] Attempting to get etcd status 8/10
[util/etcd] Attempt timed out
[util/etcd] Waiting 15s until next retry
[util/etcd] Attempting to get etcd status 9/10
[util/etcd] Attempt timed out
[util/etcd] Waiting 15s until next retry
[util/etcd] Attempting to get etcd status 10/10
[util/etcd] Attempt timed out
[upgrade/etcd] failed to healthcheck etcd: timeout waiting for etcd cluster status
[upgrade/etcd] rolling back etcd data
[upgrade/etcd] etcd data rollback successful
[upgrade/etcd] rolling back etcd manifest
[upgrade/etcd] waiting for previous etcd to become available
[util/etcd] Waiting 30s for initial delay
[util/etcd] Attempting to get etcd status 1/10
[upgrade/etcd] etcd was rolled back and is now available
[upgrade/apply] FATAL: fatal error upgrading local etcd cluster: timeout waiting for etcd cluster status, rolled the state back to pre-upgrade state
```